### PR TITLE
feat: 헤더 유형별로 추가/분리

### DIFF
--- a/src/assets/images/icons/check.svg
+++ b/src/assets/images/icons/check.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="11" viewBox="0 0 16 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.910034 4.2L6.34003 9.62999L15.1 0.869995" stroke="black" stroke-miterlimit="10"/>
+</svg>

--- a/src/assets/styles/common.scss
+++ b/src/assets/styles/common.scss
@@ -64,31 +64,7 @@
 
 
 
-.header {
-  background: #000000;
-  &-wrapper {
-    border-bottom: 1px solid #D3D3D3;
-    padding: 10px 20px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
 
-    &__logo {
-      width: 84px;
-      height: 33px;
-      .logo__img {
-        width: 100%;
-      }
-    }
-    &__menu {
-      width: 24px;
-      height: 24px;
-      .menu__icon {
-        width: 100%;
-      }
-    }
-  }
-}
 
 .petProfile {
   padding: 24px 20px 48px;

--- a/src/assets/styles/common/header.scss
+++ b/src/assets/styles/common/header.scss
@@ -1,26 +1,55 @@
 @charset 'utf-8';
 
 .header {
-    padding: 0 20px;
-    &-main {
-      display: flex;
-      justify-content: space-between;
-      padding: 20px 0;
+  border-bottom: 1px solid #E7E7E7;
+  .bg-primary {
+    background: $primaryColor;
+  }
+  
+  &-wrapper {
+    height: 52px;
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
-      &__logo {
-        content: '';
-        width: 24px;
-        height: 24px;
-        background: url('@images/common/back.svg') center center no-repeat;
-      }
-
-      &__menu {
-        content: '';
-        width: 24px;
-        height: 24px;
-        background: url('@images/common/menu.svg') center center no-repeat;
+    &__logo {
+      img {
+        width: 90px;
+        height: 36px;
       }
     }
-    
+
+    &__title {
+      @include ptBold16;
+    }
+
+    &__menu {
+      position: absolute;
+      right: 16px;
+      content: '';
+      width: 24px;
+      height: 24px;
+      background: url('@images/icons/menu.svg') center center no-repeat;
+    }
+
+    &__back {
+       position: absolute;
+       left: 16px;
+       content: '';
+       width: 24px;
+       height: 24px;
+       background: url('@images/icons/back.svg') center center no-repeat;
+     }
+ 
+     &__check {
+       position: absolute;
+       right: 16px;
+       content: '';
+       width: 24px;
+       height: 24px;
+       background: url('@images/icons/check.svg') center center no-repeat;
+     }
   }
+}
   

--- a/src/assets/styles/mixins.scss
+++ b/src/assets/styles/mixins.scss
@@ -2,6 +2,7 @@
 
 $maxWidth: 360px;
 $minHeight: 800px;
+$primaryColor: #5794F0;
 
 @mixin btnLg {
     width: 320px;

--- a/src/components/common/Header.vue
+++ b/src/components/common/Header.vue
@@ -1,19 +1,49 @@
 <template>
-  <div class="header section">
-    <div class="header-wrapper">
-      <div></div>
-      <router-link to="/" class="header-wrapper__logo">
-        <img class="logo__img" src="@images/petharu_logo.png" alt="">
-      </router-link>
-      <router-link to="/setting" class="header-wrapper__menu">
-        <img class="menu__icon" src="@images/icons/menu.svg" alt=""/>
-      </router-link>
-    </div>
-  </div>
+  <section class="header">
+    <article class="header-wrapper bg-primary" v-if="getHeaderType === 'main'">
+      <div class="header-wrapper__logo">
+        <img src="@images/petharu_logo.png" alt="" />
+      </div>
+      <router-link to="/setting" class="header-wrapper__menu" />
+    </article>
+
+    <article class="header-wrapper" v-else-if="getHeaderType === 'check'">
+      <a @click="goBack" class="header-wrapper__back"></a>
+      <div class="header-wrapper__title">{{ getTitle }}</div>
+      <button class="header-wrapper__check"></button>
+    </article>
+
+    <article class="header-wrapper" v-else-if="getHeaderType === 'drop'">
+      <a @click="goBack" class="header-wrapper__back"></a>
+      <div class="header-wrapper__title">{{ getTitle }}</div>
+      <button class="header-wrapper__check"></button>
+    </article>
+
+    <article class="header-wrapper" v-else-if="getHeaderType === 'none'">
+      <a @click="goBack" class="header-wrapper__back"></a>
+      <div class="header-wrapper__title">{{ getTitle }}</div>
+    </article>
+  </section>
 </template>
 
-<script>
-export default {}
+<script setup>
+import { computed } from '@vue/runtime-core'
+import { useStore } from 'vuex'
+import { useRouter } from 'vue-router'
+import { MODULE_NAME, TYPES } from '@store/common/headerStore.js'
+
+const store = useStore()
+const router = useRouter()
+
+const getTitle = computed(
+  () => store.getters[`${MODULE_NAME}/${TYPES.getTitle}`]
+)
+const getHeaderType = computed(
+  () => store.getters[`${MODULE_NAME}/${TYPES.getHeaderType}`]
+)
+const goBack = () => {
+  router.back()
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/constants/headerType.json
+++ b/src/constants/headerType.json
@@ -1,0 +1,6 @@
+{
+    "MAIN": "main",
+    "CHECK": "check",
+    "NONE": "none",
+    "DROP": "drop"
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,7 +1,18 @@
 import { createWebHistory, createRouter } from 'vue-router';
 import routes from './routes/index.js'
+import store from '../store/index.js'
 
 export const router = createRouter({
   history: createWebHistory(),
   routes,
 });
+
+router.beforeEach((to, from, next) => {
+  const { title, headerType } = to.meta
+  store.commit('headerStore/setTitle', title)
+  store.commit('headerStore/setHeaderType', headerType)
+  // console.log(store)
+  console.log('beforeEach', to)
+
+  next()
+})

--- a/src/router/routes/index.js
+++ b/src/router/routes/index.js
@@ -1,4 +1,5 @@
 import ROUTE from '@/constants/route.json'
+import HEADER_TYPE from '@/constants/headerType.json'
 
 import LoginRouter from '@routes/login/index.js'
 import SettingRouter from '@routes/setting/index.js'
@@ -14,21 +15,35 @@ export default [
     path: '/',
     name: ROUTE.Main,
     component: Main,
-    auth: false,
+    meta: {
+      headerType: HEADER_TYPE.MAIN
+    }
   },
   {
     path: '/login',
     component: LoginPage,
-    children: LoginRouter
+    children: LoginRouter,
+    meta: {
+      title: '로그인',
+      headerType: HEADER_TYPE.NONE
+    }
   },
   {
     path: '/setting',
     component: SettingPage,
-    children: SettingRouter
+    children: SettingRouter,
+    meta: {
+      title: '설정',
+      headerType: HEADER_TYPE.NONE
+    }
   },
   {
     path: '/family',
     component: Family,
-    children: FamilyRouter
+    children: FamilyRouter,
+    meta: {
+      title: '그룹 정보',
+      headerType: HEADER_TYPE.DROP
+    }
   }
 ]

--- a/src/router/routes/setting/index.js
+++ b/src/router/routes/setting/index.js
@@ -17,31 +17,46 @@ export default [
     {
         path: 'profile',
         name: ROUTE.Setting.Profile,
-        component: MyProfile
+        component: MyProfile,
     },
     {
         path: 'licence',
         name: ROUTE.Setting.Licence,
-        component: Licence
+        component: Licence,
+        meta: {
+            title: '라이선스'
+        }
     },
     {
         path: 'notice',
         name: ROUTE.Setting.Notice.List,
-        component: NoticeList
+        component: NoticeList,
+        meta: {
+            title: '공지사항'
+        }
     },
     {
         path: 'notice/detail/:no',
         name: ROUTE.Setting.Notice.Detail,
-        component: NoticeDetail
+        component: NoticeDetail,
+        meta: {
+            title: '공지사항'
+        }
     },
     {
         path: 'feedback',
         name: ROUTE.Setting.Feedback,
-        component: Feedback
+        component: Feedback,
+        meta: {
+            title: '피드백'
+        }
     },
     {
         path: 'withdraw',
         name: ROUTE.Setting.Withdraw,
-        component: Withdraw
+        component: Withdraw,
+        meta: {
+            title: '회원탈퇴'
+        }
     },
 ]

--- a/src/store/modules/common/headerStore.js
+++ b/src/store/modules/common/headerStore.js
@@ -1,17 +1,40 @@
-const ModuleName = 'headerStore'
+import { makeModuleTypes } from '@utils/store/index.js'
+
+const MODULE_NAME = 'headerStore'
+const TYPES = makeModuleTypes([
+  'title',
+  'getTitle',
+  'setTitle',
+  'headerType',
+  'getHeaderType',
+  'setHeaderType'
+])
 const module = {
   namespaced: true,
   state: {
-    test: 'test!'
+    title: '',
+    headerType: ''
   },
   getters: {
-    getTest(state) {
-      return state.test
+    [TYPES.getTitle](state) {
+      return state.title
+    },
+    [TYPES.getHeaderType](state) {
+      return state.headerType
+    }
+  },
+  mutations: {
+    [TYPES.setTitle](state, payload) {
+      state.title = payload
+    },
+    [TYPES.setHeaderType](state, payload) {
+      state.headerType = payload
     }
   }
 }
 
 export {
   module,
-  ModuleName
+  MODULE_NAME,
+  TYPES
 }


### PR DESCRIPTION
- 헤더 유형 "메인/체크/드롭/없음"으로 구분하여 생성
- 라우터 메타데이터를 통해 헤더 분리
- 타이틀 처리